### PR TITLE
Added windows support

### DIFF
--- a/helmsman.js
+++ b/helmsman.js
@@ -242,6 +242,12 @@ Helmsman.prototype.parse = function(argv){
   });
 
   domain.run(function() {
+    if(process.platform === "win32")
+    {
+        var p = fullPath.split(path.sep);
+        p.splice(p.length - 4, 3);
+        fullPath = p.join(path.sep) + ".cmd";
+    }
     var subcommand = spawn(fullPath, args, { stdio: 'inherit' });
 
     subcommand.on('close', function(code){


### PR DESCRIPTION
Windows creates special wrappers for things under /bin, since there's no support for hashbangs.
This points to the npm folder binaries and adds the .cmd extension, so it's runnable by process.spawn
